### PR TITLE
Update to html2canvas 0.5

### DIFF
--- a/src/feedback.js
+++ b/src/feedback.js
@@ -532,32 +532,31 @@ $.feedback = function (options) {
                     redraw(ctx, false);
                 }
                 html2canvas($('body'), {
-                    onrendered: function(canvas) {
-                        if (!settings.screenshotStroke) {
-                            redraw(ctx);
-                        }
-                        _canvas = $('<canvas id="feedback-canvas-tmp" width="'+ w +'" height="'+ dh +'"/>').hide().appendTo('body');
-                        _ctx = _canvas.get(0).getContext('2d');
-                        _ctx.drawImage(canvas, 0, sy, w, dh, 0, 0, w, dh);
-                        img = _canvas.get(0).toDataURL();
-                        $(document).scrollTop(sy);
-                        post.img = img;
-                        settings.onScreenshotTaken(post.img);
-                        if(settings.showDescriptionModal) {
-                            $('#feedback-canvas-tmp').remove();
-                            $('#feedback-overview').show();
-                            $('#feedback-overview-description-text>textarea').remove();
-                            $('#feedback-overview-screenshot>img').remove();
-                            $('<textarea id="feedback-overview-note">' + $('#feedback-note').val() + '</textarea>').insertAfter('#feedback-overview-description-text h3:eq(0)');
-                            $('#feedback-overview-screenshot').append('<img class="feedback-screenshot" src="' + img + '" />');
-                        } else {
-                            $('#feedback-module').remove();
-                            close();
-                            _canvas.remove();
-                        }
-                    },
                     proxy: settings.proxy,
                     letterRendering: settings.letterRendering
+                }).then(function(canvas) {
+                    if (!settings.screenshotStroke) {
+                        redraw(ctx);
+                    }
+                    _canvas = $('<canvas id="feedback-canvas-tmp" width="'+ w +'" height="'+ dh +'"/>').hide().appendTo('body');
+                    _ctx = _canvas.get(0).getContext('2d');
+                    _ctx.drawImage(canvas, 0, sy, w, dh, 0, 0, w, dh);
+                    img = _canvas.get(0).toDataURL();
+                    $(document).scrollTop(sy);
+                    post.img = img;
+                    settings.onScreenshotTaken(post.img);
+                    if(settings.showDescriptionModal) {
+                        $('#feedback-canvas-tmp').remove();
+                        $('#feedback-overview').show();
+                        $('#feedback-overview-description-text>textarea').remove();
+                        $('#feedback-overview-screenshot>img').remove();
+                        $('<textarea id="feedback-overview-note">' + $('#feedback-note').val() + '</textarea>').insertAfter('#feedback-overview-description-text h3:eq(0)');
+                        $('#feedback-overview-screenshot').append('<img class="feedback-screenshot" src="' + img + '" />');
+                    } else {
+                        $('#feedback-module').remove();
+                        close();
+                        _canvas.remove();
+                    }
                 });
             });
 

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <script src="http://code.jquery.com/jquery-latest.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html2canvas/0.5.0-alpha2/html2canvas.min.js"></script>
     <script src="feedback.js"></script>
     <link rel="stylesheet" href="feedback.css" />
     <script type="text/javascript">


### PR DESCRIPTION
The `onrendered` option is deprecated in version 0.5 of [html2canvas](https://github.com/niklasvh/html2canvas/), instead we have to use a Promise.
